### PR TITLE
Added %s.Name for the playlist name

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -10,8 +10,8 @@ playlist = PathAndNameOfPlaylist | Name of the smartplaylist like special://mast
 menu =                           | Name of custom or standard menu which display the widget
 unwatched = True/False           | unwatched=True to filter only unwatched items
 resume = True/False              | resume=True to filter only partially watched items
-propertie = NameOfTheProperty    | You can overwrite the default properties names Playlist<method><type><menu> by using this parameter
-                                 | example : propertie=CustomMenu1Widget1
+property = NameOfTheProperty     | You can overwrite the default properties names Playlist<method><type><menu> by using this parameter
+                                 | example : property=CustomMenu1Widget1
 
 /!\ CAUTION /!\
 resume=True can slow down script when working on playlist
@@ -33,6 +33,7 @@ Properties return to Home window (id 10000) :
 %s.Count = Number of movies in library or playlist
 %s.Unwatched = Number of unwatched movies in library or playlist
 %s.Watched = Number of watched movies in library or playlist
+%s.Name = Name of the playlist
 %s.%d.DBID
 %s.%d.Title
 %s.%d.OriginalTitle
@@ -79,6 +80,7 @@ Properties return to Home window (id 10000) :
 %s.Unwatched = Number of unwatched episodes in library or playlist
 %s.Watched = Number of watched episodes in library or playlist
 %s.TvShows = Number of TV shows in library or playlist
+%s.Name = Name of the playlist
 %s.%d.DBID
 %s.%d.Title
 %s.%d.Episode
@@ -121,6 +123,7 @@ Properties return to Home window (id 10000) :
 %s.Artists = Number of artists in library or playlist
 %s.Albums = Number of albums in library or playlist
 %s.Songs = Nombre of songs in library or playlist
+%s.Name = Name of the playlist
 %s.%d.Title
 %s.%d.Artist
 %s.%d.Genre

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.randomandlastitems" name="Random and Last items script" version="2.1.2" provider-name="MikeBZH44|Martijn">
+<addon id="script.randomandlastitems" name="Random and Last items script" version="2.1.3" provider-name="MikeBZH44|Martijn">
     <requires>
         <import addon="xbmc.python" version="2.1.0"/>
         <import addon="xbmc.json" version="6.0.0"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+v2.1.3
+- Added %s.Name property for the playlist name
+
 v2.1.2
 - Fix script error on tvshow playlist
 - Also set MPAA and studio for episodes in some cases

--- a/randomandlastitems.py
+++ b/randomandlastitems.py
@@ -46,6 +46,10 @@ def _getPlaylistType ():
        TYPE = 'Episode'
     if _type == 'songs' or _type == 'albums':
        TYPE = 'Music'
+    # get playlist name
+    _name = _doc.getElementsByTagName('name')[0].firstChild.nodeValue
+    if _name != "":
+        _setProperty( "%s.Name" % PROPERTY, str( _name ) )
 
 def _timeTook( t ):
     t = ( time.time() - t )


### PR DESCRIPTION
Sorry, there was a mistake in the previous pull request, this is the correct one. I'll need to look into squashing commits properly for the next time. :)

Description:
During the integration of this script into my skin I missed the possibility to show the name of the currently selected playlist for the script.

This small addition makes it possible to show the playlist name with the new property %s.Name
