### PR TITLE
Added new method 'Playlist' which keeps the playlist order

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Parameters (separated by comma , ):
 type = Movie/Episode/Music       | Script will request Movie database or Episode database
                                  | (/!\ Caution : upper and lower case are important)
 limit = #                        | # to limit returned results (default=10)
-method = Last/Random             | Last to get last added items and Random to get random items
+method = Last/Random/Playlist    | Last to get last added items, Random to get random items and Playlist to use the order of the playlist
 playlist = PathAndNameOfPlaylist | Name of the smartplaylist like special://masterprofile/playlists/video/children.xsp
                                  | or empty to request global database
                                  | If you set this parameter, you don't need to set type= because type will be read from playlist file

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.randomandlastitems" name="Random and Last items script" version="2.1.3" provider-name="MikeBZH44|Martijn">
+<addon id="script.randomandlastitems" name="Random and Last items script" version="2.1.4" provider-name="MikeBZH44|Martijn|`Black">
     <requires>
         <import addon="xbmc.python" version="2.1.0"/>
         <import addon="xbmc.json" version="6.0.0"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 v2.1.4
 - Add %s.%d.Runtime property for episodes or TV shows
+- Add new method 'Playlist' which keeps the playlist order
 
 v2.1.3
 - Add %s.Name property for the playlist name


### PR DESCRIPTION
This script is great for using smart playlists as widgets on the home screen but it lacked the feature to use the exact playlist order. With the new method "Playlist" the script uses the order and direction specified in the .xsp file.
